### PR TITLE
Add Google Trends scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InsiderNet
 
-This project contains example scripts for scraping public finance data from Twitter/X, Reddit, the SEC EDGAR feed, and Google Trends.  See the `notebooks/` directory for runnable scripts.
+This project contains example scripts for scraping public finance data from Twitter/X, Reddit, the SEC EDGAR feed, Google Trends, and historical stock prices.  See the `notebooks/` directory for runnable scripts.
 
 Data collected by the scripts is stored by date under the `data/` folder.  Each run outputs timestamped JSON and CSV files for reproducibility.
 
@@ -10,5 +10,6 @@ Data collected by the scripts is stored by date under the `data/` folder.  Each 
 - [`praw`](https://praw.readthedocs.io/en/latest/)
 - [`feedparser`](https://pypi.org/project/feedparser/), `requests`, `beautifulsoup4`
 - [`pytrends`](https://github.com/GeneralMills/pytrends)
+- [`yfinance`](https://pypi.org/project/yfinance/)
 
 Set the `TWITTER_BEARER_TOKEN` environment variable as well as the Reddit API credentials before running the scripts.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project contains example scripts for scraping public finance data from Twit
 
 Data collected by the scripts is stored by date under the `data/` folder.  Each run outputs timestamped JSON and CSV files for reproducibility.
 
-The `webapp/` directory includes a small Flask application with a Tailwind front end. It accepts a ticker symbol, expands Reddit search keywords using OpenAI, gathers data from Reddit, the SEC, Google Trends and Yahoo Finance, and saves a labeled price dataset.
+The `webapp/` directory includes a small Flask application with a Tailwind front end. It accepts a ticker symbol, expands Reddit search keywords using OpenAI, gathers data from Reddit, the SEC, Google Trends and Yahoo Finance, and saves both raw prices and labeled datasets. Labels are generated using the realtime `labels.py` logic as well as `labels_from_prices.py` on the stored prices.
 
 ## Requirements
 - Python 3.11 or compatible

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project contains example scripts for scraping public finance data from Twit
 
 Data collected by the scripts is stored by date under the `data/` folder.  Each run outputs timestamped JSON and CSV files for reproducibility.
 
+The `webapp/` directory includes a small Flask application with a Tailwind front end. It accepts a ticker symbol, expands Reddit search keywords using OpenAI, gathers data from Reddit, the SEC, Google Trends and Yahoo Finance, and saves a labeled price dataset.
+
 ## Requirements
 - Python 3.11 or compatible
 - [`tweepy`](https://www.tweepy.org/)
@@ -11,5 +13,7 @@ Data collected by the scripts is stored by date under the `data/` folder.  Each 
 - [`feedparser`](https://pypi.org/project/feedparser/), `requests`, `beautifulsoup4`
 - [`pytrends`](https://github.com/GeneralMills/pytrends)
 - [`yfinance`](https://pypi.org/project/yfinance/)
+- [`openai`](https://pypi.org/project/openai/) for keyword generation
+- [`flask`](https://flask.palletsprojects.com/) for the optional web front end
 
 Set the `TWITTER_BEARER_TOKEN` environment variable as well as the Reddit API credentials before running the scripts.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ The `webapp/` directory includes a small Flask application with a Tailwind front
 - [`flask`](https://flask.palletsprojects.com/) for the optional web front end
 
 Set the `TWITTER_BEARER_TOKEN` environment variable as well as the Reddit API credentials before running the scripts.
+
+The `labels_from_prices.py` script generates future price-change labels using price data collected by `historical_prices.py`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InsiderNet
 
-This project contains example scripts for scraping public finance data from Twitter/X, Reddit, and the SEC EDGAR feed.  See the `notebooks/` directory for runnable scripts.
+This project contains example scripts for scraping public finance data from Twitter/X, Reddit, the SEC EDGAR feed, and Google Trends.  See the `notebooks/` directory for runnable scripts.
 
 Data collected by the scripts is stored by date under the `data/` folder.  Each run outputs timestamped JSON and CSV files for reproducibility.
 
@@ -9,5 +9,6 @@ Data collected by the scripts is stored by date under the `data/` folder.  Each 
 - [`tweepy`](https://www.tweepy.org/)
 - [`praw`](https://praw.readthedocs.io/en/latest/)
 - [`feedparser`](https://pypi.org/project/feedparser/), `requests`, `beautifulsoup4`
+- [`pytrends`](https://github.com/GeneralMills/pytrends)
 
 Set the `TWITTER_BEARER_TOKEN` environment variable as well as the Reddit API credentials before running the scripts.

--- a/notebooks/google_trends.py
+++ b/notebooks/google_trends.py
@@ -1,0 +1,96 @@
+import json
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    from pytrends.request import TrendReq
+except ImportError as e:
+    raise ImportError(
+        "pytrends is required to run this script. Install via `pip install pytrends`."
+    ) from e
+
+# Example mapping of tickers to company and CEO names. Extend as needed.
+STOCKS = {
+    "AAPL": {"company": "Apple Inc", "ceo": "Tim Cook"},
+    "MSFT": {"company": "Microsoft Corporation", "ceo": "Satya Nadella"},
+    "AMZN": {"company": "Amazon.com, Inc.", "ceo": "Andy Jassy"},
+}
+
+DAYS_BACK = 90  # Number of days of interest data to fetch
+
+
+def build_queries() -> list[str]:
+    """Return a unique list of queries from ticker, company and CEO names."""
+    queries: list[str] = []
+    for ticker, info in STOCKS.items():
+        queries.append(ticker)
+        queries.append(info["company"])
+        queries.append(info["ceo"])
+    # Preserve order but remove duplicates
+    return list(dict.fromkeys(queries))
+
+
+def fetch_daily_interest(pytrends: TrendReq, query: str) -> list[dict]:
+    """Fetch daily Google Trends interest for a single query."""
+    end_date = datetime.utcnow().date()
+    start_date = end_date - timedelta(days=DAYS_BACK)
+    timeframe = f"{start_date} {end_date}"
+    pytrends.build_payload([query], timeframe=timeframe)
+    df = pytrends.interest_over_time()
+    records = []
+    if df.empty:
+        return records
+    for date, row in df.iterrows():
+        records.append(
+            {
+                "query": query,
+                "date": date.strftime("%Y-%m-%d"),
+                "interest": int(row[query]),
+                "is_partial": bool(row.get("isPartial", False)),
+            }
+        )
+    return records
+
+
+def save_json(data: list[dict], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_csv(data: list[dict], path: Path) -> None:
+    if not data:
+        return
+    fields = list(data[0].keys())
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def main():
+    pytrends = TrendReq(hl="en-US", tz=360)
+    queries = build_queries()
+    all_records: list[dict] = []
+    for q in queries:
+        try:
+            all_records.extend(fetch_daily_interest(pytrends, q))
+        except Exception as e:  # noqa: BLE001
+            print(f"Error fetching trends for '{q}': {e}")
+
+    root_dir = Path(__file__).resolve().parents[1]
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    out_dir = root_dir / "data" / "trends" / today
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.utcnow().strftime("%H%M%S")
+    json_path = out_dir / f"trends_{timestamp}.json"
+    csv_path = out_dir / f"trends_{timestamp}.csv"
+
+    save_json(all_records, json_path)
+    save_csv(all_records, csv_path)
+    print(f"Saved {len(all_records)} records to {json_path} and {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/historical_prices.py
+++ b/notebooks/historical_prices.py
@@ -1,0 +1,81 @@
+import json
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    import yfinance as yf
+except ImportError as e:
+    raise ImportError(
+        "yfinance is required to run this script. Install via `pip install yfinance`."
+    ) from e
+
+# Sample tickers. Extend as needed.
+TICKERS = ["AAPL", "MSFT", "AMZN"]
+
+# Number of days of historical prices to fetch
+DAYS_BACK = 365
+
+
+def fetch_prices(ticker: str) -> list[dict]:
+    """Return daily adjusted close and volatility for a ticker."""
+    end_date = datetime.utcnow().date()
+    start_date = end_date - timedelta(days=DAYS_BACK)
+    df = yf.download(ticker, start=start_date, end=end_date, progress=False, interval="1d")
+    df = df.dropna(subset=["Adj Close"])
+    records: list[dict] = []
+    for date, row in df.iterrows():
+        adj_close = float(row["Adj Close"])
+        high = float(row.get("High", adj_close))
+        low = float(row.get("Low", adj_close))
+        volatility = (high - low) / adj_close if adj_close else 0.0
+        records.append(
+            {
+                "ticker": ticker,
+                "date": date.strftime("%Y-%m-%d"),
+                "adj_close": adj_close,
+                "volatility": volatility,
+            }
+        )
+    return records
+
+
+def save_json(data: list[dict], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_csv(data: list[dict], path: Path) -> None:
+    if not data:
+        return
+    fields = list(data[0].keys())
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def main() -> None:
+    all_records: list[dict] = []
+    for ticker in TICKERS:
+        try:
+            all_records.extend(fetch_prices(ticker))
+        except Exception as e:  # noqa: BLE001
+            print(f"Error fetching prices for {ticker}: {e}")
+
+    root_dir = Path(__file__).resolve().parents[1]
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    out_dir = root_dir / "data" / "prices" / today
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.utcnow().strftime("%H%M%S")
+    json_path = out_dir / f"prices_{timestamp}.json"
+    csv_path = out_dir / f"prices_{timestamp}.csv"
+
+    save_json(all_records, json_path)
+    save_csv(all_records, csv_path)
+    print(f"Saved {len(all_records)} records to {json_path} and {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/label.py
+++ b/notebooks/label.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import numpy as np
+
+import pandas as pd
+import numpy as np
+import datetime
+from pathlib import Path
+
+
+def create_labels(prices_path: Path, output_dir: Path, volatility_threshold: float = 0.02) -> None:
+    df = pd.read_csv(prices_path)
+    df["date"] = pd.to_datetime(df["date"])
+    df.sort_values(by=["ticker", "date"], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+
+    # Shifted data for label generation
+    df["future_close"] = df.groupby("ticker")["close"].shift(-3)
+    df["pct_change"] = ((df["future_close"] - df["close"]) / df["close"]).round(4)
+    df["binary_label"] = (df["pct_change"] > 0).astype(int)
+
+    # Volatility label based on 3-day rolling std dev of next prices
+    df["rolling_std"] = (
+        df.groupby("ticker")["close"].transform(lambda x: x.shift(-1).rolling(3).std())
+    )
+    df["volatility_label"] = (df["rolling_std"] > volatility_threshold).astype(int)
+
+    # Drop rows with NaNs from label calculation
+    df.dropna(subset=["future_close", "pct_change", "rolling_std"], inplace=True)
+
+    # Save output
+    timestamp = datetime.datetime.utcnow().strftime("%H%M%S")
+    label_dir = output_dir / "labels" / datetime.datetime.utcnow().strftime("%Y-%m-%d")
+    label_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = label_dir / f"labels_{timestamp}.json"
+    csv_path = label_dir / f"labels_{timestamp}.csv"
+
+    df_out = df[[
+        "ticker", "date", "close", "future_close", "pct_change", "binary_label", "volatility_label"
+    ]]
+    df_out.to_csv(csv_path, index=False)
+    df_out.to_json(json_path, orient="records", indent=2, date_format="iso")
+
+    print(f"✅ Saved {len(df_out)} labeled rows to {csv_path} and {json_path}")
+
+def main():
+    prices_path = Path("/Users/rakeshcavala/Desktop/InsiderNet/data/prices/2025-06-19/prices_151250.csv")
+    output_dir = Path("/Users/rakeshcavala/Desktop/InsiderNet/data")
+    create_labels(prices_path, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/labels.py
+++ b/notebooks/labels.py
@@ -1,0 +1,98 @@
+"""Compute future price change labels for a ticker."""
+import csv
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    import yfinance as yf
+except ImportError as e:  # pragma: no cover - handled by runtime
+    raise ImportError(
+        "yfinance is required to run this script. Install via `pip install yfinance`."
+    ) from e
+
+# Days to look ahead when calculating future close
+LOOK_AHEAD_DAYS = 5
+
+
+def fetch_price_history(ticker: str, days_back: int = 365) -> list[dict]:
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=days_back)
+    df = yf.download(ticker, start=start, end=end, progress=False, interval="1d")
+    df = df.dropna(subset=["Adj Close"])
+    records: list[dict] = []
+    for date, row in df.iterrows():
+        adj_close = float(row["Adj Close"])
+        high = float(row.get("High", adj_close))
+        low = float(row.get("Low", adj_close))
+        volatility = (high - low) / adj_close if adj_close else 0.0
+        records.append(
+            {
+                "ticker": ticker,
+                "date": date.strftime("%Y-%m-%d"),
+                "close": adj_close,
+                "volatility": volatility,
+            }
+        )
+    return records
+
+
+def add_labels(records: list[dict]) -> list[dict]:
+    """Add future_close, pct_change, binary_label and volatility_label."""
+    for i, row in enumerate(records):
+        if i + LOOK_AHEAD_DAYS < len(records):
+            future_close = records[i + LOOK_AHEAD_DAYS]["close"]
+        else:
+            future_close = row["close"]
+        pct_change = (future_close - row["close"]) / row["close"] if row["close"] else 0.0
+        binary_label = 1 if pct_change > 0 else 0
+        volatility_label = 1 if row["volatility"] > 0.05 else 0
+        row.update(
+            {
+                "future_close": future_close,
+                "pct_change": pct_change,
+                "binary_label": binary_label,
+                "volatility_label": volatility_label,
+            }
+        )
+    return records
+
+
+def save_json(data: list[dict], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_csv(data: list[dict], path: Path) -> None:
+    if not data:
+        return
+    fields = list(data[0].keys())
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def main(ticker: str) -> None:
+    records = fetch_price_history(ticker)
+    records = add_labels(records)
+
+    root_dir = Path(__file__).resolve().parents[1]
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    out_dir = root_dir / "data" / "labels" / ticker / today
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.utcnow().strftime("%H%M%S")
+    json_path = out_dir / f"labels_{timestamp}.json"
+    csv_path = out_dir / f"labels_{timestamp}.csv"
+
+    save_json(records, json_path)
+    save_csv(records, csv_path)
+    print(f"Saved {len(records)} rows to {json_path} and {csv_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import sys
+
+    ticker = sys.argv[1] if len(sys.argv) > 1 else "AAPL"
+    main(ticker)

--- a/notebooks/labels_from_prices.py
+++ b/notebooks/labels_from_prices.py
@@ -1,0 +1,75 @@
+"""Generate price change labels from saved historical price data."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+
+def create_labels(prices_path: Path, output_dir: Path, look_ahead: int = 3, volatility_threshold: float = 0.02) -> None:
+    """Create labels from a CSV of historical prices.
+
+    Parameters
+    ----------
+    prices_path:
+        Path to a CSV file with columns ``ticker``, ``date`` and ``adj_close``.
+    output_dir:
+        Directory under which ``labels/YYYY-MM-DD`` will be created.
+    look_ahead:
+        Number of days ahead to use when computing the ``future_close``.
+    volatility_threshold:
+        Rolling standard deviation threshold to determine ``volatility_label``.
+    """
+    df = pd.read_csv(prices_path)
+    df["date"] = pd.to_datetime(df["date"])
+    df.sort_values(by=["ticker", "date"], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+
+    # Price column may be named 'adj_close' from the scraper
+    price_col = "adj_close" if "adj_close" in df.columns else "close"
+
+    df["future_close"] = df.groupby("ticker")[price_col].shift(-look_ahead)
+    df["pct_change"] = (df["future_close"] - df[price_col]) / df[price_col]
+    df["binary_label"] = (df["pct_change"] > 0).astype(int)
+
+    df["rolling_std"] = df.groupby("ticker")[price_col].transform(lambda x: x.shift(-1).rolling(look_ahead).std())
+    df["volatility_label"] = (df["rolling_std"] > volatility_threshold).astype(int)
+
+    df.dropna(subset=["future_close", "pct_change", "rolling_std"], inplace=True)
+
+    timestamp = datetime.utcnow().strftime("%H%M%S")
+    label_dir = Path(output_dir) / "labels" / datetime.utcnow().strftime("%Y-%m-%d")
+    label_dir.mkdir(parents=True, exist_ok=True)
+
+    df_out = df[[
+        "ticker",
+        "date",
+        price_col,
+        "future_close",
+        "pct_change",
+        "binary_label",
+        "volatility_label",
+    ]].rename(columns={price_col: "close"})
+
+    csv_path = label_dir / f"labels_{timestamp}.csv"
+    json_path = label_dir / f"labels_{timestamp}.json"
+
+    df_out.to_csv(csv_path, index=False)
+    df_out.to_json(json_path, orient="records", indent=2, date_format="iso")
+    print(f"Saved {len(df_out)} labeled rows to {csv_path} and {json_path}")
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate labels from price data")
+    parser.add_argument("prices", type=Path, help="Path to historical prices CSV")
+    parser.add_argument("output", type=Path, help="Root data directory")
+    args = parser.parse_args()
+
+    create_labels(args.prices, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,114 @@
+"""Simple Flask front end for data collection."""
+from __future__ import annotations
+
+import os
+import csv
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from flask import Flask, render_template, request
+
+try:
+    import openai
+except ImportError as e:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "openai is required to run this app. Install via `pip install openai`."
+    ) from e
+
+from notebooks import labels, google_trends, historical_prices, reddit_scraper, sec_edgar_scraper
+
+app = Flask(__name__)
+
+
+def generate_keywords(ticker: str) -> list[str]:
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if not openai.api_key:
+        return [ticker]
+    prompt = f"Generate a short comma-separated list of keywords related to {ticker} for Reddit searches. Include the company and CEO names if known."
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=32,
+        )
+        text = resp.choices[0].message.content
+        return [kw.strip() for kw in text.split(",") if kw.strip()]
+    except Exception as exc:  # noqa: BLE001
+        print(f"OpenAI error: {exc}")
+        return [ticker]
+
+
+def search_reddit(keywords: list[str], limit: int = 20):
+    reddit = reddit_scraper.get_reddit_client()
+    start_ts = int((datetime.utcnow() - timedelta(days=30)).timestamp())
+    posts = []
+    for kw in keywords:
+        query = kw
+        for submission in reddit.subreddit("all").search(
+            query, sort="new", time_filter="month", limit=limit
+        ):
+            posts.append(
+                {
+                    "id": submission.id,
+                    "title": submission.title,
+                    "created_utc": submission.created_utc,
+                    "score": submission.score,
+                    "num_comments": submission.num_comments,
+                }
+            )
+    return posts
+
+
+def save_json(data: list[dict], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_csv(data: list[dict], path: Path) -> None:
+    if not data:
+        return
+    fields = list(data[0].keys())
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/track", methods=["POST"])
+def track():
+    ticker = request.form.get("ticker", "").upper()
+    if not ticker:
+        return render_template("index.html", message="No ticker provided")
+
+    keywords = generate_keywords(ticker)
+    reddit_posts = search_reddit(keywords)
+    trends = google_trends.fetch_daily_interest(
+        google_trends.TrendReq(hl="en-US", tz=360), ticker
+    )
+    filings = sec_edgar_scraper.parse_entries(ticker)
+    labels_data = labels.fetch_price_history(ticker)
+    labels_data = labels.add_labels(labels_data)
+
+    root = Path(__file__).resolve().parents[1]
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    out_dir = root / "data" / ticker / today
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.utcnow().strftime("%H%M%S")
+
+    save_json(reddit_posts, out_dir / f"reddit_{timestamp}.json")
+    save_json(trends, out_dir / f"trends_{timestamp}.json")
+    save_json(filings, out_dir / f"edgar_{timestamp}.json")
+    save_json(labels_data, out_dir / f"labels_{timestamp}.json")
+
+    return render_template("index.html", message=f"Data collected for {ticker}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    app.run(debug=True)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>InsiderNet Tracker</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-lg mx-auto bg-white p-8 rounded shadow">
+        <h1 class="text-2xl font-bold mb-4">Track a Stock</h1>
+        <form action="/track" method="post" class="space-y-4">
+            <input type="text" name="ticker" placeholder="Ticker (e.g. AAPL)" class="w-full border p-2 rounded" required>
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Submit</button>
+        </form>
+        {% if message %}
+        <p class="mt-4 text-green-700">{{ message }}</p>
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `google_trends.py` to scrape daily interest scores from Google Trends for stock tickers, company names and CEO names
- save results to timestamped JSON and CSV files under `data/trends`
- document Google Trends scraper and `pytrends` requirement

## Testing
- `python -m py_compile notebooks/google_trends.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854237f7cb483329ebae9d05bbf983f